### PR TITLE
Add .NET Standard 2.0 target framework

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: [ 'net6.0', 'net7.0' ]
+        dotnet-version: [ 'netstandard2.0', 'net6.0', 'net7.0' ]
     env:
       DOTNET_NOLOGO: true
 

--- a/README.md
+++ b/README.md
@@ -45,12 +45,6 @@ Right now there are two components currently available for use:
 
 ### PowerShell Module
 
-> **⚠️ Note**
->  
-> The PowerShell module **requires** PowerShell 7.2 or higher to run.
->  
-> There are no plans at the moment to support Windows Powershell 5.1, which is installed on Windows 10/11 by default, due to the reliance on targetting .NET 6 and higher.
-
 You can install the [PowerShell module from the PowerShell Gallery](https://www.powershellgallery.com/packages/SmallsOnline.WindowsBuildNumbers.Pwsh) by running the following command in a PowerShell console:
 
 ```powershell

--- a/src/SmallsOnline.WindowsBuildNumbers.Lib/SmallsOnline.WindowsBuildNumbers.Lib.csproj
+++ b/src/SmallsOnline.WindowsBuildNumbers.Lib/SmallsOnline.WindowsBuildNumbers.Lib.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
@@ -24,5 +24,9 @@
     <DebugSymbols>false</DebugSymbols>
     <DebugType>none</DebugType>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="7.0.3" />
+  </ItemGroup>
 
 </Project>

--- a/src/SmallsOnline.WindowsBuildNumbers.Lib/helpers/DateTimeHelpers.cs
+++ b/src/SmallsOnline.WindowsBuildNumbers.Lib/helpers/DateTimeHelpers.cs
@@ -12,11 +12,56 @@ public static class DateTimeHelpers
     /// <returns>Whether the input date is the second Tuesday of the month.</returns>
     public static bool IsSecondTuesdayOfTheMonth(DateTimeOffset inputDate)
     {
+#if NETSTANDARD2_0
+        DateTimeOffset inputDateOnly = new(inputDate.Year, inputDate.Month, inputDate.Day, 0, 0, 0, 0, inputDate.Offset);
+#else
         DateOnly inputDateOnly = ConvertToDateOnly(inputDate);
+#endif
 
         return inputDateOnly == GetSecondTuesdayOfTheMonth(inputDate);
     }
 
+#if NETSTANDARD2_0
+    /// <summary>
+    /// Get the second Tuesday of a month.
+    /// </summary>
+    /// <param name="inputDate">The input date to get.</param>
+    /// <returns>The second Tuesday of the month.</returns>
+    public static DateTimeOffset GetSecondTuesdayOfTheMonth(DateTimeOffset inputDate)
+    {
+        // Create a new DateTimeOffset for the first of the month from the input date.
+        DateTimeOffset firstDateOfMonth = new(inputDate.Year, inputDate.Month, 1, 0, 0, 0, 0, inputDate.Offset);
+
+        // Generate a DateTimeOffset for the second Tuesday of the month.
+        // This is done by determining if the first date of the month is a Tuesday or not.
+        DateTimeOffset firstTuesdayOfMonth = (firstDateOfMonth.DayOfWeek == DayOfWeek.Tuesday) switch
+        {
+            // If the first date of the month is not a Tuesday,
+            // subtract the DayOfWeek value for Tuesday from the DayOfWeek value for the first date of the month.
+            // Then use that value to add/subtract days (Depending on the value).
+            false => firstDateOfMonth.AddDays(DayOfWeek.Tuesday - firstDateOfMonth.DayOfWeek),
+
+            // If the first date of the month is a Tuesday,
+            // then set the first Tuesday of the month to the first date of the month.
+            _ => firstDateOfMonth
+        };
+
+        // Generate a DateTimeOffset for the second Tuesday of the month.
+        // This is done by determining if the first Tuesday of the month is less than the first date of the month.
+        DateTimeOffset secondTuesdayOfMonth = (firstTuesdayOfMonth.Month < firstDateOfMonth.Month) switch
+        {
+            // If the first Tuesday of the month is not less than the first date of the month,
+            // then add 7 days to the first Tuesday of the month.
+            false => firstTuesdayOfMonth.AddDays(7),
+
+            // If the first Tuesday of the month is less than the first date of the month,
+            // then add 14 days to the first Tuesday of the month.
+            _ => firstTuesdayOfMonth.AddDays(14)
+        };
+
+        return secondTuesdayOfMonth;
+    }
+#else
     /// <summary>
     /// Get the second Tuesday of a month.
     /// </summary>
@@ -56,7 +101,9 @@ public static class DateTimeHelpers
 
         return secondTuesdayOfMonth;
     }
+#endif
 
+#if NET6_0_OR_GREATER
     /// <summary>
     /// Convert a <see cref="DateTimeOffset"/> input to a <see cref="DateOnly"/> value.
     /// </summary>
@@ -66,4 +113,5 @@ public static class DateTimeHelpers
     {
         return new(inputDate.Year, inputDate.Month, inputDate.Day);
     }
+#endif
 }

--- a/src/SmallsOnline.WindowsBuildNumbers.Pwsh/SmallsOnline.WindowsBuildNumbers.Pwsh.csproj
+++ b/src/SmallsOnline.WindowsBuildNumbers.Pwsh/SmallsOnline.WindowsBuildNumbers.Pwsh.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -25,10 +26,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.0">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>compile</IncludeAssets>
-        </PackageReference>
+        <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" />
       <ProjectReference Include="..\SmallsOnline.WindowsBuildNumbers.Lib\SmallsOnline.WindowsBuildNumbers.Lib.csproj" />
     </ItemGroup>
 

--- a/src/SmallsOnline.WindowsBuildNumbers.Pwsh/SmallsOnline.WindowsBuildNumbers.Pwsh.psd1
+++ b/src/SmallsOnline.WindowsBuildNumbers.Pwsh/SmallsOnline.WindowsBuildNumbers.Pwsh.psd1
@@ -12,10 +12,11 @@
 RootModule = "SmallsOnline.WindowsBuildNumbers.Pwsh.dll"
 
 # Version number of this module.
-ModuleVersion = "1.0.0"
+ModuleVersion = "1.1.0"
 
 # Supported PSEditions
 CompatiblePSEditions = @(
+    "Desktop",
     "Core"
 )
 
@@ -35,7 +36,7 @@ Copyright = "2022"
 Description = "Get release information about Windows 10/11 feature updates."
 
 # Minimum version of the PowerShell engine required by this module
-PowerShellVersion = "7.2.0"
+PowerShellVersion = "5.1.0"
 
 # Name of the PowerShell host required by this module
 # PowerShellHostName = ""


### PR DESCRIPTION
This adds support for targeting `netstandard2.0`. This should allow for Windows PowerShell 5.1 support.